### PR TITLE
Мобайл

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -608,14 +608,12 @@ p.partners-number-medium {
     color: #f8292d;
 }
 
-@media all and (min-width:680px){
-    .project-item h3 {
-        font-family: 'Helvetica Neue Cyr Bold';
-        font-size: 14px;
-        line-height: 80px;
-        margin-bottom: 0;
-    }
-
+.project-item h3 {
+    font-family: 'Helvetica Neue Cyr Bold';
+    font-size: 17px;
+    line-height: 80px;
+    margin-bottom: 0;
+    text-align: center;
 }
 
 @media all and (max-width:680px) {
@@ -628,6 +626,7 @@ p.partners-number-medium {
         border-top: #e1dede solid 1px;
     }
     .project-item p {
+        display: inline-block;
         font-family: 'Helvetica Neue Cyr Bold';
         font-size: 25px;
         line-height: 25px;
@@ -639,11 +638,9 @@ p.partners-number-medium {
         width: 90%;
         margin-left: 1%;
     }
-
-
-
     .project-item h3 {
         font-size: 17px;
+        line-height: 25px;
         text-align: center;
         height: 25px;
         margin-bottom: 0;


### PR DESCRIPTION
Сделать меньше лого
Титул однозначно меньше, чтобы поместился в две строки
Иконку скролл вниз
Опустить серый фон до конца экрана
Достижения должны превращаться в таблицу (см. темплейт)
Уже сделать белую полоску для меню
Отступ от заголовка 1 строка
На айфоне красная лента перед заголовком не должна равнятся по верхнему краю текста, текст должен идти как бы посередине (в гугл эмуляторе все ок, но на реальном айфоне нет)
Убираем лишнее пространство (в других секциях норм)
Делаем расстояние меньше после названия статьи
Мы можем зафиксировать экран, чтобы нельзя было сдвигать контент в бок (см. телеграм)?